### PR TITLE
database: fix json key

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Test with pytest
         env:
-          TMDB_API_KEY_V3: ${{ secrets.TMDB_API_KEY_V3 }}
-          TWITCH_CLIENT_ID: ${{ secrets.TWITCH_CLIENT_ID }}
-          TWITCH_CLIENT_SECRET: ${{ secrets.TWITCH_CLIENT_SECRET }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           python -m pytest -v

--- a/tests/unit/test_updater.py
+++ b/tests/unit/test_updater.py
@@ -6,7 +6,6 @@ verifying and updating requests to update the PluggerDB database. The tests in t
 updater module is functioning correctly by validating URLs and checking that the correct IDs are returned.
 """
 # standard imports
-import os
 
 # local imports
 import updater

--- a/updater.py
+++ b/updater.py
@@ -170,12 +170,12 @@ def process_github_url(url: str, categories: Optional[list] = None) -> dict:
                 original_submission = False
                 with lock:
                     try:
-                        og_data[github_data['id']]['plugin_added_by']
+                        og_data[str(github_data['id'])]['plugin_added_by']
                     except KeyError:
                         original_submission = True
-                        og_data[github_data['id']]['plugin_added_by'] = os.environ['ISSUE_AUTHOR_USER_ID']
+                        og_data[str(github_data['id'])]['plugin_added_by'] = os.environ['ISSUE_AUTHOR_USER_ID']
                     finally:
-                        og_data[github_data['id']]['plugin_edited_by'] = os.environ['ISSUE_AUTHOR_USER_ID']
+                        og_data[str(github_data['id'])]['plugin_edited_by'] = os.environ['ISSUE_AUTHOR_USER_ID']
 
                 # update contributor info
                 update_contributor_info(original=original_submission, base_dir='database')


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
On issue updates, the key in the database was an integer in some cases instead of a string, which caused a key error. This PR fixes that.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
