### PR TITLE
database: separate prs from issues

### DIFF
--- a/tests/unit/test_updater.py
+++ b/tests/unit/test_updater.py
@@ -12,9 +12,7 @@ import updater
 
 valid_submission = dict(
     github_url='https://github.com/LizardByte/Plugger',
-    categories=[
-        'Utility',
-    ],
+    categories='Utility',
     other_category='',
     additional_comments=''
 )
@@ -22,15 +20,16 @@ valid_submission = dict(
 
 def test_check_github():
     """Tests if the provided YouTube url is valid and returns a valid url."""
-    api_url = updater.check_github(data=valid_submission)
+    git_owner, git_repo = updater.check_github(data=valid_submission)
 
-    assert api_url == 'https://api.github.com/repos/LizardByte/Plugger'
+    assert git_owner == 'LizardByte'
+    assert git_repo == 'Plugger'
 
 
 def test_process_github_url():
     """Tests if the provided GitHub url is valid and returns a valid url."""
-    api_url = updater.check_github(data=valid_submission)
-    github_data = updater.process_github_url(url=api_url)
+    git_owner, git_repo = updater.check_github(data=valid_submission)
+    github_data = updater.process_github_url(owner=git_owner, repo=git_repo)
 
     assert github_data is not None
     assert github_data['id']


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Add individual counts for open issues and open PRs since GitHub counts them all as issues by default.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
