### PR TITLE
database: remove bundle from name

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -266,6 +266,14 @@ def process_github_url(owner: str, repo: str, categories: Optional[str] = None) 
             og_data[str(github_data['id'])]['releases'] = releases
             og_data[str(github_data['id'])]['thumb_image_url'] = thumb_image_url
 
+            # remove `.bundle` from end of name and full name
+            test = '.bundle'
+            t_len = len(test)
+            test_keys = ['name', 'full_name']
+            for k in test_keys:
+                if og_data[str(github_data['id'])][k].endswith(test):
+                    og_data[str(github_data['id'])][k] = og_data[str(github_data['id'])][k][:-t_len]
+
         # test wiki pages and overwrite value if wiki is empty
         with lock:  # ensure only one thread is making a request to GitHub at a time
             if github_data['has_wiki']:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Remove `.bundle` from `name` and `full_name` keys if it exists.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
