### PR TITLE
database: fix contributor edit counter

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -220,12 +220,13 @@ def process_github_url(owner: str, repo: str, submission: Optional[dict] = None)
         except NameError:
             pass
         else:
-            if args.daily_update:
-                # move these keys to non GitHub data dict as they don't exist in the GitHub API
-                for k in og_data[str(github_data['id'])]:
-                    if k not in github_data:
-                        non_github_data[k] = og_data[str(github_data['id'])][k]
+            # move these keys to non GitHub data dict as they don't exist in the GitHub API
+            for k in og_data[str(github_data['id'])]:
+                if k not in github_data:
+                    print(k)
+                    non_github_data[k] = og_data[str(github_data['id'])][k]
 
+            if args.daily_update:
                 categories = og_data[str(github_data['id'])]['categories']
 
                 try:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fixes issue where editor count would not increment on plugin edits.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
