### PR TITLE
updater: reduce default max tries in `requests_loop`

### DIFF
--- a/updater.py
+++ b/updater.py
@@ -48,7 +48,7 @@ def exception_writer(error: Exception, name: str, end_program: bool = False) -> 
 def requests_loop(url: str,
                   headers: Optional[dict] = None,
                   method: Callable = requests.get,
-                  max_tries: int = 10,
+                  max_tries: int = 8,
                   allow_statuses: list = [requests.codes.ok]) -> requests.Response:
     count = 0
     while count <= max_tries:


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Reduces the default `max_tries` parameter of `requests_loop` from 10 to 8. The 10th loop would sleep for about 17 minutes, with a total time sleeping of about 34 minutes. Reducing to 8 tries will have a total time sleeping of about 8 minutes.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
