### PR TITLE
ci: remove nightly branch

### DIFF
--- a/.github/workflows/update-pages.yml
+++ b/.github/workflows/update-pages.yml
@@ -3,7 +3,7 @@ name: Update
 
 on:
   pull_request:
-    branches: [master, nightly]
+    branches: [master]
     types: [opened, synchronize, reopened]
   push:
     branches: [master]
@@ -136,5 +136,5 @@ jobs:
           author_name: ${{ secrets.GH_BOT_NAME }}
           directory: gh-pages
           branch: gh-pages
-          force: true
+          force: false
           message: automatic-update-${{ steps.date.outputs.date }}

--- a/updater.py
+++ b/updater.py
@@ -420,22 +420,23 @@ def process_github_url(owner: str, repo: str, submission: Optional[dict] = None)
                 if og_data[str(github_data['id'])][k].endswith(test):
                     og_data[str(github_data['id'])][k] = og_data[str(github_data['id'])][k][:-t_len]
 
+        # todo - find more reliable way to test if wiki exists
         # test wiki pages and overwrite value if wiki is empty
-        with lock:  # ensure only one thread is making a request to GitHub at a time
-            if github_data['has_wiki']:
-                test_url = f'https://github.com/search?q=repo:{owner}/{repo}&type=wikis'
-                test_wiki = requests_loop(url=test_url, github_wait=True)
-                if test_wiki.status_code == requests.codes.ok:
-                    # see if string in contents
-                    # not logged in
-                    if f'We couldn’t find any wiki pages matching &#39;repo:{owner}/{repo}&#39;' in test_wiki.text:
-                        og_data[str(github_data['id'])]['has_wiki'] = False
-                    # logged in
-                    if 'Your search did not match any <!-- -->wikis' in test_wiki.text:
-                        og_data[str(github_data['id'])]['has_wiki'] = False
-                else:
-                    og_data[str(github_data['id'])]['has_wiki'] = False
-                    exception_writer(error=Exception(f'Unable to search wiki for {owner}/{repo}'), name='GitHub Wiki')
+        # with lock:  # ensure only one thread is making a request to GitHub at a time
+        #     if github_data['has_wiki']:
+        #         test_url = f'https://github.com/search?q=repo:{owner}/{repo}&type=wikis'
+        #         test_wiki = requests_loop(url=test_url, github_wait=True)
+        #         if test_wiki.status_code == requests.codes.ok:
+        #             # see if string in contents
+        #             # not logged in
+        #             if f'We couldn’t find any wiki pages matching &#39;repo:{owner}/{repo}&#39;' in test_wiki.text:
+        #                 og_data[str(github_data['id'])]['has_wiki'] = False
+        #             # logged in
+        #             if 'Your search did not match any <!-- -->wikis' in test_wiki.text:
+        #                 og_data[str(github_data['id'])]['has_wiki'] = False
+        #         else:
+        #             og_data[str(github_data['id'])]['has_wiki'] = False
+        #             exception_writer(error=Exception(f'Unable to search wiki for {owner}/{repo}'), name='GitHub Wiki')
 
         try:
             args.issue_update


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
- Remove `nightly` branch from pull request events
- Change force push to `false`
- Temporarily disable wiki validation as we are getting rate limited too often. See #590.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
